### PR TITLE
fix broken libiconv package

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -20,7 +20,7 @@ dependencies:
 - icu=58.2=0
 - jpeg=9b=2
 - libffi=3.2.1=3
-- libiconv=1.15=0
+- libiconv=1.15=h470a237_3
 - libpng=1.6.34=0
 - libxcb=1.12=1
 - libxml2=2.9.7=0


### PR DESCRIPTION
libiconv package was marked as broken in conda-forge