### PR TITLE
Add conda-forge broken channel

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,6 +2,7 @@ name:
 channels:
 - conda-forge
 - defaults
+- conda-forge/label/broken
 dependencies:
 - backports=1.0=py36_1
 - backports.functools_lru_cache=1.5=py36_0


### PR DESCRIPTION
Since this is a frozen environment for durability purposes, we allow pulling broken packages if needed.